### PR TITLE
Remove network permission

### DIFF
--- a/de.rwth_aachen.ient.YUView.yaml
+++ b/de.rwth_aachen.ient.YUView.yaml
@@ -7,7 +7,6 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --share=ipc
-  - --share=network
   - --filesystem=host
   - --env=QT_NO_FT_CACHE=1
   - --device=dri


### PR DESCRIPTION
The permission is exclusively used to check for updates which is implemented by checking the running versions git hash against the head of the upstream repo. This results in an "newer version" dialog to be shown on every launch.

Disallowing network access causes this dialog to not be shown.
